### PR TITLE
use latest tifffile

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-tifffile==2020.10.1
+tifffile==2023.9.26

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-requirements = [ 'tifffile==2020.10.1' ]
+requirements = [ 'tifffile==2023.9.26' ]
 
 setup_requirements = [ ]
 


### PR DESCRIPTION
I noticed that installing this package had downgraded my `tifffile`, meaning that my scripts using `from tifffile import tiffcomment` had broken.

Quick superficial test seems to show no problems with this change, I don't expect any are likely.