### PR TITLE
Expand allowed tifffile versions and bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-requirements = [ 'tifffile==2023.9.26' ]
+requirements = [ 'tifffile>=2020.10.1' ]
 
 setup_requirements = [ ]
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/ilan-gold/generate-tiff-offsets',
-    version='0.1.7',
+    version='0.1.8',
     zip_safe=False,
 )


### PR DESCRIPTION
The current version on PyPI is 0.1.7 which still depends on `tifffile==2020.10.1`. I see it is updated here on github last year but there is no release on PyPI. We could also just expand the allowed version ranges. 

For context i am seeing this type of error
```sh
uv pip install "vitessce[all]>=3.4.0" "scikit-image==0.24.0"
  × No solution found when resolving dependencies:
  ╰─▶ Because generate-tiff-offsets==0.1.7 depends on tifffile==2020.10.1 and only generate-tiff-offsets<=0.1.7 is available, we can conclude that
      generate-tiff-offsets>=0.1.7 depends on tifffile==2020.10.1.
      And because vitessce[all]==3.4.0 depends on generate-tiff-offsets>=0.1.7, we can conclude that vitessce[all]==3.4.0 depends on tifffile==2020.10.1.
      And because scikit-image==0.24.0 depends on tifffile>=2022.8.12 and only vitessce[all]<=3.4.0 is available, we can conclude that
      scikit-image==0.24.0 and vitessce[all]>=3.4.0 are incompatible.
      And because you require vitessce[all]>=3.4.0 and scikit-image==0.24.0, we can conclude that your requirements are unsatisfiable.
```